### PR TITLE
feat: added cache control response header for manifest.json

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 	max-age=31104000,
 	public,
 	must-revalidate'''
-
+[[headers]]
   for = "/manifest.json"
     [headers.values]
     # Multi-value headers are expressed with multi-line strings.


### PR DESCRIPTION
Improvement Seen
- after adding cache-control to 1 year for rupee.png icon
- totally avoided network call to netlify server for png
- also since rupee.png was a High priority critical resource
- it helped a lot in reducing overall load time