### PR TITLE
fix: netlify build error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -85,5 +85,8 @@
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
       "prettier --write"
     ]
+  },
+  "engines": {
+    "node": ">=12.20.0 <=14"
   }
 }


### PR DESCRIPTION
Reason
- since copy-webpack-plugin need node verion >= 12.20.0
- and netlify was using version 12.18.0
- build was getting failed

Solution
- added engines specifying which node version is required
- also added npmrc setting strict engine to true