### PR TITLE
feat: fixed not found error on refresh during

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -10,7 +10,8 @@ module.exports = merge(common, {
     hot: true,
     port: 3000,
     liveReload: false,
-    compress: false
+    compress: false,
+    historyApiFallback: true
   },
   plugins: [
     new ReactRefreshWebpackPlugin(),


### PR DESCRIPTION
local development
Why does the issue arise
- since during development webpack-dev-server is run
- which is basically just a tiny express server with compile on change and hot reload
- so lets say i am on route /spend-analysis
- and I hit refresh
- the request goes to express server
- since we don't have any explicitly route specified
- for /spend-analysis it throws 404
- hope you can go to days back where everything was server from express
- we used to hit a route and then would get the html served from server
- since we are using client side routing (CSR)
- routing is handled by the browser not the server
- react-router code gets loaded when we hit /
How To fix the issue
- by setting historyApiFallback too true in webpack dev config
- we are telling webpack that during development
- all those resources with 404s will fallback to /index.html
- which will load the react router and other code required for routing
- then they properly render the component for a given url
- which we specify in Route