### PR TITLE
feat: fix reload 404 error on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
+# Cache headers for rupee.png file
 [[headers]]
   # Define which paths this specific [[headers]] block will cover.
   for = "/rupee.png"
@@ -7,6 +8,8 @@
 	max-age=31104000,
 	public,
 	must-revalidate'''
+
+# Cache header for manifest.json file
 [[headers]]
   for = "/manifest.json"
     [headers.values]
@@ -15,3 +18,7 @@
     max-age=31104000,
     public,
     must-revalidate'''
+
+# Redirect all 404s to /index.html
+[[redirects]]
+  /* /index.html 404


### PR DESCRIPTION
Issue
- whenever the page was reloaded apart from home page
- cannot get url 404 error came
Why the error came
- since we are dependent on client side routing aka CSR
- so all 404s will be redirected to /index.html
- which will load the react router code
- and CSR will work fine then